### PR TITLE
Add PG_CPPFLAGS to silence error and warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ OBJS = $(SRCS:.c=.o)
 REGRESS = pguecc_test_raw pguecc_test_public
 
 PG_CONFIG = pg_config
+PG_CPPFLAGS = -Wno-vla -Wno-declaration-after-statement -Wno-missing-prototypes
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
Reported upstream in https://github.com/ameensol/pg-ecdsa/issues/1

$ make
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument -mmacosx-version-min=10.12 -I. -I./ -I/Applications/Postgres.app/Contents/Versions/13/include/postgresql/server -I/Applications/Postgres.app/Contents/Versions/13/include/postgresql/internal -I/Applications/Postgres.app/Contents/Versions/13/share/icu -I/Applications/Postgres.app/Contents/Versions/13/include/libxml2 -I/Applications/Postgres.app/Contents/Versions/13/include -c -o pguecc.o pguecc.c
pguecc.c:205:14: error: variable length array used [-Werror,-Wvla]
char pub_key[uECC_curve_public_key_size(curve) + VARHDRSZ];
^
pguecc.c:206:14: error: variable length array used [-Werror,-Wvla]
char prv_key[uECC_curve_private_key_size(curve) + VARHDRSZ];
^
2 errors generated.
make: *** [pguecc.o] Error 1